### PR TITLE
[Fix] Add paths-ignore for push trigger

### DIFF
--- a/.github/workflows/check_directory_name.yml
+++ b/.github/workflows/check_directory_name.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'ex[1-9]/**'
 
 jobs:
   comment:


### PR DESCRIPTION
# What

- `paths-ignore`を追加

# Why

- #20 で追加し忘れていたため